### PR TITLE
Added early and late scripts keys and main.sh modification

### DIFF
--- a/config/domain.yaml
+++ b/config/domain.yaml
@@ -71,8 +71,11 @@ bmcuser: 2
 files:
   main:
     - main.sh
-  earlyscripts:
-    - script-to-run-before-core.sh
+  setup:
+    - local-script.sh
+    - https://raw.githubusercontent.com/alces-software/metalware-default/master/files/remote-script.sh
+    - non-existent-local-script.sh
+    - http://example.com/non-existent-remote-script.sh
   core:
     - core/base.sh
     - core/network-base.sh
@@ -83,13 +86,8 @@ files:
     - core/configs/yum.upstream
     - core/configs/authorized_keys
     - core/configs/ntp
-
   scripts:
     - local-script.sh
     - https://raw.githubusercontent.com/alces-software/metalware-default/master/files/remote-script.sh
     - non-existent-local-script.sh
     - http://example.com/non-existent-remote-script.sh
-  latescripts:
-    - script-to-run-after-all-other-scripts.sh
-  configs:
-    - demo-config.conf

--- a/config/domain.yaml
+++ b/config/domain.yaml
@@ -71,6 +71,8 @@ bmcuser: 2
 files:
   main:
     - main.sh
+  earlyscripts:
+    - script-to-run-before-core.sh
   core:
     - core/base.sh
     - core/network-base.sh
@@ -87,5 +89,7 @@ files:
     - https://raw.githubusercontent.com/alces-software/metalware-default/master/files/remote-script.sh
     - non-existent-local-script.sh
     - http://example.com/non-existent-remote-script.sh
+  latescripts:
+    - script-to-run-after-all-other-scripts.sh
   configs:
     - demo-config.conf

--- a/files/demo-config.conf
+++ b/files/demo-config.conf
@@ -1,2 +1,0 @@
-
-This is an example config file.

--- a/files/main.sh
+++ b/files/main.sh
@@ -26,50 +26,26 @@ curl "<%= file.url %>" > "$CORE_DIR/<%= file.name %>"
   <% end %>
 <% end %>
 
+
 echo
-echo 'Running early scripts:'
-<% alces.files.earlyscripts.each do |script| %>
+echo 'Running user setup scripts:'
+<% alces.files.setup.each do |script| %>
   <% if script.error %>
 echo '<%= script.name %>: <%= script.error %>'
   <% else %>
 curl "<%= script.url %>" | /bin/bash
   <% end %>
 <% end %>
+
 
 echo 'Running Alces core setup'
 run_script base
 run_script networking
 
 
-# Below are examples for how users could make use of `files` feature.
-
 echo
-echo 'Running scripts:'
+echo 'Running user scripts:'
 <% alces.files.scripts.each do |script| %>
-  <% if script.error %>
-echo '<%= script.name %>: <%= script.error %>'
-  <% else %>
-curl "<%= script.url %>" | /bin/bash
-  <% end %>
-<% end %>
-
-mkdir -p /tmp/configs
-echo
-echo 'Requesting configs:'
-<% alces.files.configs.each do |config| %>
-  <% if config.error %>
-echo '<%= config.name %>: <%= config.error %>'
-  <% else %>
-config_file=/tmp/configs/<%= config.name %>
-curl "<%= config.url %>" > "$config_file"
-echo "Config $config_file saved with contents:"
-cat "$config_file"
-  <% end %>
-<% end %>
-
-echo
-echo 'Running late scripts:'
-<% alces.files.latescripts.each do |script| %>
   <% if script.error %>
 echo '<%= script.name %>: <%= script.error %>'
   <% else %>

--- a/files/main.sh
+++ b/files/main.sh
@@ -26,6 +26,15 @@ curl "<%= file.url %>" > "$CORE_DIR/<%= file.name %>"
   <% end %>
 <% end %>
 
+echo
+echo 'Running early scripts:'
+<% alces.files.earlyscripts.each do |script| %>
+  <% if script.error %>
+echo '<%= script.name %>: <%= script.error %>'
+  <% else %>
+curl "<%= script.url %>" | /bin/bash
+  <% end %>
+<% end %>
 
 echo 'Running Alces core setup'
 run_script base
@@ -55,6 +64,16 @@ config_file=/tmp/configs/<%= config.name %>
 curl "<%= config.url %>" > "$config_file"
 echo "Config $config_file saved with contents:"
 cat "$config_file"
+  <% end %>
+<% end %>
+
+echo
+echo 'Running late scripts:'
+<% alces.files.latescripts.each do |script| %>
+  <% if script.error %>
+echo '<%= script.name %>: <%= script.error %>'
+  <% else %>
+curl "<%= script.url %>" | /bin/bash
   <% end %>
 <% end %>
 


### PR DESCRIPTION
This feature would allow scripts to be executed either before or after `core` and `scripts. This is particularly useful with local yum repository setup as it allows for the local repo config to be put into place _before_ `base.sh` runs `yum -y update`