### PR TITLE
Add server config where build interface is defined

### DIFF
--- a/server.yaml
+++ b/server.yaml
@@ -1,0 +1,3 @@
+
+# Interface to build cluster on.
+build_interface: "<%= networks.pri.interface %>"


### PR DESCRIPTION
This is a very minor change to this repo, but submitting this PR with a longish explanation of why this change was made (along with the much larger supporting changes in Metalware) for anyone interested. This is part of supporting https://trello.com/c/zJLDMucI, but the same file will probably also be used for future similar features. The explanation for adding this file and feature is as follows:

This new config file is now rendered by Metalware with each `configure` command, after the configure process and prior to the `genders` and `hosts` files being rendered. This rendered file is then later loaded by Metalware to determine the IP of the Metalware deployment server on this
interface, which is used when forming parts of the `alces` namespace like `alces.hostip` and the various `alces.*_url` fields.

The reason this file needs to exist rather than just defining this in the repo config files is because the `build_interface` parameter needs to be loaded by Metalware to form many parts of the `alces` namespace, but we want to be able to define this parameter itself in terms of parts of the `alces` namespace or other config values. This means there would be the potential for a cycle to be formed, where `build_interface` depends on part of the config or `alces` namespace which then depends on
`build_interface` in some way.

One way around this would be to change how Metalware loads configs to do this incrementally, only loading parameters in the configs as they are needed to render part of a template or other config value, and deferring rendering parts of the config until their dependencies are available. This would be very complex and could still lead to confusing situations where parts of the config recursively depend on each other, making them impossible to resolve.

Instead, this is now a 2 step process where the server config is rendered with `configure` commands, and it can later be loaded and used in other parts of Metalware without risk of the data used to render it changing underneath. I think this will make things simpler and more understandable.

Currently the `build_interface` is defined in the simplest possible way, to just be the same as the primary network interface, but this can be changed if needed to be based on another part of the config.