### PR TITLE
Adjust use of `index` due to change to 1-indexing

### DIFF
--- a/configure.yaml
+++ b/configure.yaml
@@ -39,7 +39,7 @@ questions:
 
   pri_network_ip: &pri_network_ip
     question: 'IP for nodes on the primary network'
-    default: '10.10.<%= alces.group_index %>.<%= alces.index + 1 %>'
+    default: '10.10.<%= alces.group_index %>.<%= alces.index %>'
 
   pri_network_netmask: &pri_network_netmask
     question: 'Netmask for the primary network'
@@ -60,7 +60,7 @@ questions:
 
   mgt_network_ip: &mgt_network_ip
     question: 'IP for nodes on the management network'
-    default: '10.11.<%= alces.group_index %>.<%= alces.index + 1 %>'
+    default: '10.11.<%= alces.group_index %>.<%= alces.index %>'
 
   mgt_network_netmask: &mgt_network_netmask
     question: 'Netmask for the management network'
@@ -82,7 +82,7 @@ questions:
 
   ib_network_ip: &ib_network_ip
     question: 'IP for nodes on the InfiniBand network'
-    default: '10.12.<%= alces.group_index %>.<%= alces.index + 1 %>'
+    default: '10.12.<%= alces.group_index %>.<%= alces.index %>'
 
   ib_network_netmask: &ib_network_netmask
     question: 'Netmask for the InfiniBand network'


### PR DESCRIPTION
We now start the `index` for each node from 1 (see https://github.com/alces-software/metalware/pull/162/commits/9af7775fb4f337e8be913c89857ff0ff296b49ea), so we no longer need to add 1 to this to form a valid IP, as it should already do so.

@ColonelPanicks: can you have a quick look at this and let me know if I've missed anything. Only other use of `alces.index` I can see is https://github.com/alces-software/metalware-default/blob/master/config/domain.yaml#L61, which we don't increment so I assume we don't need to change now. However presumably this wasn't always a valid IP already as it would be `10.11.200.0` for the first node in a group, so perhaps we're using this in some unusual way somewhere?