### PR TITLE
Revert "Set server interface to hardcoded em1"

### DIFF
--- a/server.yaml
+++ b/server.yaml
@@ -1,3 +1,3 @@
 
 # Interface to build cluster on.
-build_interface: "em1"
+build_interface: "<%= networks.pri.interface %>"


### PR DESCRIPTION
This change was breaking things for a machine without an `em1` interface; I believe this was a workaround for the issue fixed in https://github.com/alces-software/metalware/pull/213 so this should no longer be necessary.