### PR TITLE
Secondary genders groups for machine type and role

### DIFF
--- a/configure.yaml
+++ b/configure.yaml
@@ -37,6 +37,22 @@ questions:
     identifier: genders_host_range
     question: "Genders host range specifier for this group, e.g. 'node01,node[05-08]'"
 
+  - &genders_host_type
+    identifier: genders_host_type
+    question: 'What type of machines are in this group?'
+    default: 'physical'
+    choices:
+      - 'physical'
+      - 'virtual'
+
+  - &genders_host_role
+    identifier: genders_host_role
+    question: 'What are the roles of machines in this group?'
+    default: 'compute'
+    choices:
+      - 'compute'
+      - 'infra'
+
   - &genders_additional_groups
     identifier: genders_additional_groups
     question: "Additional genders groups for this group, e.g. 'gpunodes,nodes'; the group being configured is the primary group"
@@ -277,6 +293,8 @@ domain:
 
 group:
   - *genders_host_range
+  - *genders_host_type
+  - *genders_host_role
   - *genders_additional_groups
 
   - *kickstart_template

--- a/genders/default
+++ b/genders/default
@@ -1,5 +1,5 @@
 
 <% alces.groups do |group| -%>
 <% additional_groups = group.answers.genders_additional_groups.empty? ? '' : ',' + group.answers.genders_additional_groups -%>
-<%= group.answers.genders_host_range %>    <%= group.name %><%= additional_groups %>
+<%= group.answers.genders_host_range %>    <%= group.name %>,<%= group.answer.genders_host_type %>,<%= group.answer.genders_host_role%><%= additional_groups %>
 <% end -%>


### PR DESCRIPTION
A couple of thoughts
- Should `config/*.yaml` files be present by default in the repo for these possible types and roles?
- How does gender hierarchical inheritance work?
- Should role or type take higher priority in inheritance?