### PR TITLE
Updated genders template for orphan nodes

### DIFF
--- a/genders/default
+++ b/genders/default
@@ -1,8 +1,8 @@
 <% groups.each do |group| -%>
-<% if group.name == 'local' -%>
-local    local
-<% else -%>
+<% next if group.name == 'orphan' -%>
 <% additional_groups = group.answer.genders_additional_groups.empty? ? '' : ',' + group.answer.genders_additional_groups -%>
 <%= group.answer.genders_host_range %>    <%= group.name %><%= additional_groups %>
 <% end -%>
+<% orphan_list.each do |node| -%>
+<%= node %>    orphan
 <% end -%>


### PR DESCRIPTION
Orphan nodes do not appear in the answers for the orphan group. Instead they must be added from `alces.orphan_list`. Also the local node is now an orphan node. This means it does not need to be added explicitly as it will be created on `metal configure local`